### PR TITLE
fix: pashov-m-01 - It’s not possible to execute a rewards migration of a BatonFarm

### DIFF
--- a/src/Nft.sol
+++ b/src/Nft.sol
@@ -497,7 +497,7 @@ contract Nft is ERC721AUpgradeable, Ownable, ERC2981 {
     /**
      * @notice Initiates a migration of yield farming rewards to a new target address.
      */
-    function intiateYieldFarmMigration(address target) external onlyOwner {
+    function initiateYieldFarmMigration(address target) external onlyOwner {
         yieldFarm.initiateMigration(target);
         emit InitiateYieldFarmMigration(target);
     }

--- a/test/SeedYieldFarm.t.sol
+++ b/test/SeedYieldFarm.t.sol
@@ -316,13 +316,13 @@ contract SeedYieldFarmTest is Test {
 
         vm.stopPrank();
 
-        nft.intiateYieldFarmMigration(address(0x123));
+        nft.initiateYieldFarmMigration(address(0x123));
         assertEq(nft.yieldFarm().migration(), address(0x123));
     }
 
     function test_RevertIf_InitiateYieldFarmMigrationCallerIsNotOwner() public {
         vm.prank(babe);
         vm.expectRevert(Unauthorized.selector);
-        nft.intiateYieldFarmMigration(address(0x123));
+        nft.initiateYieldFarmMigration(address(0x123));
     }
 }


### PR DESCRIPTION
Fixes: [M-01] It’s not possible to execute a rewards migration of a BatonFarm

Adds an intiateYieldFarmMigration method that allows the Nft owner to initiate a migration of yield farming rewards