### PR TITLE
fix: pashov-l-01 - The refund mechanism can be used by accounts with allowances

### DIFF
--- a/src/Nft.sol
+++ b/src/Nft.sol
@@ -281,7 +281,8 @@ contract Nft is ERC721AUpgradeable, Ownable, ERC2981 {
         if (block.timestamp <= _refundParams.mintEndTimestamp) revert MintNotExpired();
 
         for (uint256 i = 0; i < tokenIds.length; i++) {
-            _burn(tokenIds[i], true);
+            if (ownerOf(tokenIds[i]) != msg.sender) revert Unauthorized();
+            _burn(tokenIds[i]);
         }
 
         uint256 totalRefundAmount =


### PR DESCRIPTION
fixes: [L-02] The refund mechanism can be used by accounts with allowances

Adds a check to ensure that the person burning the NFT owns the tokenId