### PR TITLE
fix: bytes032-m-02 - Unbounded royalty rate in NFT Creation

### DIFF
--- a/src/Nft.sol
+++ b/src/Nft.sol
@@ -48,6 +48,7 @@ contract Nft is ERC721AUpgradeable, Ownable, ERC2981 {
     error MigrationNotInitiated();
     error MigrationTargetNotMatched();
     error MaxMintSupplyTooLarge();
+    error RoyaltyRateTooHigh();
 
     /// ░░░░░░░░░░░░░░░░░░░░░░░░░
     /// Events
@@ -188,6 +189,8 @@ contract Nft is ERC721AUpgradeable, Ownable, ERC2981 {
         ) {
             revert InvalidRefundParams();
         }
+
+        if (royaltyRate > 3000) revert RoyaltyRateTooHigh();
 
         __ERC721A_init(name_, symbol_);
         _initializeOwner(owner_);


### PR DESCRIPTION
fixes: 5.2.2 Unbounded royalty rate in NFT Creation